### PR TITLE
Allow covr

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -82,7 +82,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Install covr and do covr test coverage
-        if: matrix.config.r == 'devel'
+        # if: matrix.config.r == 'devel'
         run: |
           remotes::install_cran("covr")
           covr::codecov()


### PR DESCRIPTION
`covr` disabled by default GHA script generated by `usethis` due to run only on R devel; now enable on all runs